### PR TITLE
Linux install fails on Ubuntu / Python 3.8

### DIFF
--- a/steampipe_alchemy/db.py
+++ b/steampipe_alchemy/db.py
@@ -264,7 +264,7 @@ def get_linux():
     with open(bin_dir / 'steampipe.tar.gz', 'wb') as f:
         f.write(resp.read())
 
-    with tarfile.TarFile(bin_dir / 'steampipe.tar.gz', 'r') as z:
+    with tarfile.open(bin_dir / 'steampipe.tar.gz', 'r') as z:
         z.extractall(bin_dir)
 
 


### PR DESCRIPTION
In the current version of `steampipe_alchemy` I get an error when trying to run examples that include the `sa.install` command.  The error message is  
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/tarfile.py", line 186, in nti
    s = nts(s, "ascii", "strict")
  File "/usr/lib/python3.8/tarfile.py", line 170, in nts
    return s.decode(encoding, errors)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xfe in position 0: ordinal not in range(128)
```

This occurs on Ubuntu 20 and Python 3.8.5 running in a virtual env.

I tracked this down to a error in the tarfile extract code.  the `tar.gz` file is downloaded but needs call `tarfile.open` command prior to calling `extractall` not sure what `tarfile.TarFile` should do, but I could not find examples of it and `tarfile.open` works for me.